### PR TITLE
Explicitly include iostream for GCC 5.1

### DIFF
--- a/units/flyspi/source/Vlmh6518.cpp
+++ b/units/flyspi/source/Vlmh6518.cpp
@@ -1,6 +1,7 @@
 #include "Vlmh6518.h"
 #include <bitset>
 #include <exception>
+#include <iostream>
 
 using namespace std;
 

--- a/units/flyspi/tools/check_prom.cpp
+++ b/units/flyspi/tools/check_prom.cpp
@@ -2,6 +2,7 @@ using namespace std;
 
 #include <string>
 #include <list>
+#include <iostream>
 #include <fstream>
 
 #include "logger.h"

--- a/units/flyspi/tools/flansch_test.cpp
+++ b/units/flyspi/tools/flansch_test.cpp
@@ -3,6 +3,7 @@ using namespace std;
 
 #include <string>
 #include <list>
+#include <iostream>
 #include <fstream>
 
 #include "logging_ctrl.h"

--- a/units/flyspi/tools/flash_fpga.cpp
+++ b/units/flyspi/tools/flash_fpga.cpp
@@ -10,6 +10,7 @@ using namespace std;
 
 #include <string>
 #include <list>
+#include <iostream>
 #include <fstream>
 
 #include <boost/program_options.hpp>

--- a/units/flyspi/tools/read_temperature.cpp
+++ b/units/flyspi/tools/read_temperature.cpp
@@ -2,6 +2,7 @@ using namespace std;
 
 #include <string>
 #include <list>
+#include <iostream>
 #include <fstream>
 
 #include <boost/program_options.hpp>

--- a/units/flyspi/tools/read_usb_clk.cpp
+++ b/units/flyspi/tools/read_usb_clk.cpp
@@ -3,6 +3,7 @@ using namespace std;
 
 #include <string>
 #include <list>
+#include <iostream>
 #include <fstream>
 
 #include "logger.h"


### PR DESCRIPTION
The code seemed to rely on non-standard implicit inclusion of
iostream which broke with newer GCC versions. This patch adds
iostream to the files in which I got a compilation error with
GCC 5.1.