### PR TITLE
Fix support for older compilers (<= GCC5) where C++11 is not the default

### DIFF
--- a/units/vmodule_base/test/wscript
+++ b/units/vmodule_base/test/wscript
@@ -31,4 +31,5 @@ def build(bld):
         source          = bld.path.ant_glob('*.cpp'),
         install_path    = os.path.join('bin', 'tests'),
         use             = [ 'vmodule_objects' ],
+        cxxflags        = [ '-std=c++11' ],
     )

--- a/wscript
+++ b/wscript
@@ -36,7 +36,7 @@ def configure(cfg):
 
 def build(bld):
 
-    cxxflags = []
+    cxxflags = [ '-std=c++11' ]
 
     SOURCES = [
         'units/vmodule_base/source/vmodule.cpp',
@@ -108,5 +108,6 @@ def build(bld):
             features        = 'cxx cxxprogram gtest',
             source          = bld.path.ant_glob('units/flyspi/test/*.cpp'),
             use             = [ 'vmodule_objects' ],
-            skip_run        = True
+            skip_run        = True,
+            cxxflags        = cxxflags
             )


### PR DESCRIPTION
Without these changes the code no longer compiles with GCC 5 as the C++11 mode is not switched on, problem was introduced by commit 210885997f0124975cb17cb6710d5fffec585513
